### PR TITLE
Better compatibility with clients. Eg. Transmit for OSX.

### DIFF
--- a/lib/ftpd/session.rb
+++ b/lib/ftpd/session.rb
@@ -197,6 +197,7 @@ module Ftpd
     end
 
     def cmd_list(argument)
+      argument = argument_without_options(argument)
       close_data_server_socket_when_done do
         ensure_logged_in
         ensure_file_system_supports :dir
@@ -209,6 +210,7 @@ module Ftpd
     end
 
     def cmd_nlst(argument)
+      argument = argument_without_options(argument)
       close_data_server_socket_when_done do
         ensure_logged_in
         ensure_file_system_supports :dir
@@ -219,6 +221,10 @@ module Ftpd
       end
     end
 
+    def argument_without_options(argument)
+      argument.gsub(/(-\S*\s?)/,'')
+    end
+    
     def cmd_type(argument)
       ensure_logged_in
       syntax_error unless argument =~ /^(\S)(?: (\S+))?$/


### PR DESCRIPTION
Transmit sends an: LIST -a

So we should ignore any list/nlst arguments that start with a dash.
