### PR TITLE
Update README to have users set server.interface = '127.0.0.1'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+.DS_Store
 *#
 pkg/
 doc-api/

--- a/README.md
+++ b/README.md
@@ -28,38 +28,44 @@ impacting you (or at least want to let many of them build up before
 you have to deal with them), then lock your Gemfile down to a minor
 release (e.g. :version => '~> 0.5.0').
 
+Ftpd currently does not support IPV6 and therefore you are urged to
+ensure binding the server interface as `server.interface = '127.0.0.1'`.
+
 ## Hello World
 
 This is examples/hello_world.rb, a bare minimum FTP server.  It allows
 any user/password, and serves files in a temporary directory.  It
 binds to an ephemeral port on the local interface:
 
-    require 'ftpd'
-    require 'tmpdir'
+```ruby
+require 'ftpd'
+require 'tmpdir'
 
-    class Driver
+class Driver
 
-      def initialize(temp_dir)
-        @temp_dir = temp_dir
-      end
+  def initialize(temp_dir)
+    @temp_dir = temp_dir
+  end
 
-      def authenticate(user, password)
-        true
-      end
+  def authenticate(user, password)
+    true
+  end
 
-      def file_system(user)
-        Ftpd::DiskFileSystem.new(@temp_dir)
-      end
+  def file_system(user)
+    Ftpd::DiskFileSystem.new(@temp_dir)
+  end
 
-    end
+end
 
-    Dir.mktmpdir do |temp_dir|
-      driver = Driver.new(temp_dir)
-      server = Ftpd::FtpServer.new(driver)
-      server.start
-      puts "Server listening on port #{server.bound_port}"
-      gets
-    end
+Dir.mktmpdir do |temp_dir|
+  driver = Driver.new(temp_dir)
+  server = Ftpd::FtpServer.new(driver)
+  server.interface = '127.0.0.1'
+  server.start
+  puts "Server listening on port #{server.bound_port}"
+  gets
+end
+```
 
 A more full-featured example that allows TLS and takes options is in
 examples/example.rb
@@ -115,15 +121,17 @@ Here are the methods a file system may expose:
 
 Ftpd includes a disk based file system:
 
-    class Driver
+```ruby
+class Driver
 
-      ...
+  ...
 
-      def file_system(user)
-        Ftpd::DiskFileSystem.new('/var/lib/ftp')
-      end
+  def file_system(user)
+    Ftpd::DiskFileSystem.new('/var/lib/ftp')
+  end
 
-    end
+end
+```
 
 **Warning**: The DiskFileSystem allows file and directory modification
 including writing, renaming, deleting, etc.  If you want a read-only
@@ -146,25 +154,30 @@ allows only the operations you want, or which mixes the predefined
 modules with your customizations, as in this silly example that allows
 uploads but then throws them away.
 
-    class BlackHole
-      def write(ftp_path, contents)
-      end
-    end
+```ruby
+class BlackHole
+  def write(ftp_path, contents)
+  end
+end
 
-    class CustomDiskFileSystem
-      include DiskFileSystem::Base
-      include DiskFileSystem::Read
-      include BlackHole
-    end
+class CustomDiskFileSystem
+  include DiskFileSystem::Base
+  include DiskFileSystem::Read
+  include BlackHole
+end
+```
 
 ## Configuration
 
 Configuration is done via accessors on {Ftpd::FtpServer}.  For
 example, to set the session timeout to 10 minutes:
 
-      server = Ftpd::FtpServer.new(driver)
-      server.session_timeout = 10 * 60
-      server.start
+```ruby
+server = Ftpd::FtpServer.new(driver)
+server.session_timeout = 10 * 60
+server.interface = '127.0.0.1'
+server.start
+```
 
 You can set any of these attributes before starting the server:
 


### PR DESCRIPTION
Hi all,

@wconrad - as discussed, I've updated the README to resolve #4 and also enabled syntax highlighting for the code examples as well.

Best M.
