### PR TITLE
pwd return status should be 250

### DIFF
--- a/lib/ftpd/session.rb
+++ b/lib/ftpd/session.rb
@@ -559,7 +559,7 @@ module Ftpd
     end
 
     def pwd
-      reply %Q(257 "#{@name_prefix}" is current directory)
+      reply %Q(250 "#{@name_prefix}" is current directory)
     end
 
     TRANSMISSION_MODES = {


### PR DESCRIPTION
I stumbled on a (Juniper JunOS devices) client that is closely checking the return codes and would fail to put files when CWD . returned with a 257 (pathname created) instead of a 250 (requested file action okay)
