### PR TITLE
Handle shutdowns niclely in ruby 2.1.2

### DIFF
--- a/lib/ftpd/server.rb
+++ b/lib/ftpd/server.rb
@@ -74,7 +74,7 @@ module Ftpd
               IO.select([@server_socket])
               sleep(0.2)
               retry
-            rescue Errno::EBADF
+            rescue Errno::EBADF, Errno::ENOTSOCK
               raise unless @stopping
               @stopping = false
               break


### PR DESCRIPTION
Ruby 2.1.2 seems to raise a Errno::ENOTSOCK instead of Errno::EBADF if a socket is closed while another thread is listening.
