### PR TITLE
Avoid busy wait by joining with server thread

### DIFF
--- a/bin/ftpdrb
+++ b/bin/ftpdrb
@@ -210,7 +210,7 @@ module FTPDrb
       puts "FTP server started.  Press ENTER or c-C to stop it"
       $stdout.flush
       begin
-        gets
+        @server.join
       rescue Interrupt
         puts "Interrupt"
       end


### PR DESCRIPTION
Fix for issue 47. I realize you put in a call to gets, but what would happen if a user enters a line and hits return? I guess that would kill the server. I tested this and it seems to work fine with ^C.