### PR TITLE
Fix remote denial of service attack due to race condition in peer_ip

### DIFF
--- a/lib/ftpd/connection_tracker.rb
+++ b/lib/ftpd/connection_tracker.rb
@@ -54,6 +54,7 @@ module Ftpd
         @connections[ip] += 1
         @socket_ips[socket.object_id] = ip
       end
+    rescue Errno::ENOTCONN
     end
 
     # Stop tracking a connection
@@ -61,6 +62,7 @@ module Ftpd
     def stop_track(socket)
       @mutex.synchronize do
         ip = @socket_ips.delete(socket.object_id)
+        break unless ip
         if (@connections[ip] -= 1) == 0
           @connections.delete(ip)
         end


### PR DESCRIPTION
If the client disconnects from the socket before the server has the chance to get the clients IP, it raises an exception and terminates the server. This happens for example when the server is scanned by `nmap`.

#### Backtrace
```
[...]/ftpd-2.0.1/lib/ftpd/gets_peer_address.rb:31:in `getpeername': Transport endpoint is not connected - getpeername(2) (Errno::ENOTCONN)
        from [...]/ftpd-2.0.1/lib/ftpd/gets_peer_address.rb:31:in `peer_ip'
        from [...]/ftpd-2.0.1/lib/ftpd/connection_tracker.rb:52:in `block in start_track'
        from [...]/ftpd-2.0.1/lib/ftpd/connection_tracker.rb:51:in `synchronize'
        from [...]/ftpd-2.0.1/lib/ftpd/connection_tracker.rb:51:in `start_track'
        from [...]/ftpd-2.0.1/lib/ftpd/connection_tracker.rb:40:in `track'
        from [...]/ftpd-2.0.1/lib/ftpd/ftp_server.rb:208:in `session'
        from [...]/ftpd-2.0.1/lib/ftpd/server.rb:119:in `block in start_session_thread'
```

## Reproduction steps

Start a server and scan it with nmap.

## Affection versions

I found ftpd version 2.0.1 to be affected by the bug.

## Fix

My patch fixes the issue.