### PR TITLE
Allow "QUIT " without issuing syntax error

### DIFF
--- a/examples/example.rb
+++ b/examples/example.rb
@@ -36,7 +36,7 @@ module Example
       # When running on travisci, the LOGNAME environment variable is
       # not set, but we require it to be set.
       @user = ENV['LOGNAME'] || "test"
-      @password = ''
+      @password = 'test'
       @account = ''
       @session_timeout = default_session_timeout
       @log = nil

--- a/lib/ftpd/command_loop.rb
+++ b/lib/ftpd/command_loop.rb
@@ -26,6 +26,8 @@ module Ftpd
                 error "Syntax error, command unrecognized: #{s.chomp}", 500
               end
               command_sequence_checker.check command
+              # remove empty arguments caused by trailing space, e.g. "QUIT "
+              argument = nil if argument.to_s.empty?
               execute_command command, argument
             rescue FtpServerError => e
               reply e.message_with_code


### PR DESCRIPTION
I have an IP camera that has a trailing space in its QUIT command.

E.g.
```
220 wconrad/ftpd 2.1.0
USER ...
331 Password required
PASS ...
230 Logged in
TYPE I
200 Type set to I
CWD .//20180918/images/
250 "/20180918/images" is current directory
PASV
227 Entering passive mode (10,0,2,20,153,173)
STOR P18091815472210.jpg
150 Opening BINARY mode data connection
226 Transfer complete
QUIT 
501 Syntax error
```

By allowing an empty/blank argument parameter to the quit command this error can be suppressed, meaning less noise in the logs.

Worth adding?