### PR TITLE
Add ruby 2.5, 2.6 and 2.7 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
 - 2.2
 - 2.3
 - 2.4
+- 2.5
+- 2.6
+- 2.7
 sudo: false
 script: bundle exec rake test
 dist: precise


### PR DESCRIPTION
I'd love to use this in a high version of ruby. 